### PR TITLE
feat: add devtools support to Browser struct

### DIFF
--- a/internal/agent/runtime/browser.go
+++ b/internal/agent/runtime/browser.go
@@ -108,6 +108,7 @@ type Browser struct {
 
     mu       sync.Mutex
     log      *logEmitter
+    devtools devToolsInternal
 }
 
 // NewBrowser launches a headless Chrome instance reachable through chromedp.

--- a/internal/cli/tui/tui.go
+++ b/internal/cli/tui/tui.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"


### PR DESCRIPTION
- Introduced a new field `devtools` in the Browser struct to facilitate internal DevTools management.
- This enhancement lays the groundwork for improved browser automation capabilities and integration with DevTools features.